### PR TITLE
Mimic React.js behaviour for capture event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ class MyComponent extends Component {
     return (
       <div>
         <EventListener target="window" onResize={this.handleResize} />
-        <EventListener target={document} onMouseMove={this.handleMouseMove} capture={true} />
+        <EventListener target={document} onMouseMoveCapture={this.handleMouseMove} />
       </div>
     );
   }

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -181,7 +181,7 @@ describe('EventListener', () => {
     });
   });
 
-  describe('props: capture', () => {
+  describe('when using capture phase', () => {
     it('attaches listeners with capture', () => {
       let button;
       const calls = [];
@@ -190,8 +190,7 @@ describe('EventListener', () => {
         <div>
           <EventListener
             target={document}
-            capture={true}
-            onClick={() => calls.push('outer')}
+            onClickCapture={() => calls.push('outer')}
           />
           <button
             ref={(c) => button = c}


### PR DESCRIPTION
Here is my proposal how it could look to make it work in the same way as in React.js.

### Pros:
- Works as React event handlers
- Possibility of more detailed control over multiple handlers
  - so I no longer need two components for two different handlers

### Cons:
- Breaking change

If we don't want to introduce a breaking change, capture prop can remain there, although the API shouldn't provide two ways to do the same thing.

Closes #9 