### PR TITLE
add / removeEventListener passive options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ It's using the React lifecycle to bind and unbind at the right time.
 
 ```js
 import React, {Component} from 'react';
-import EventListener from 'react-event-listener';
+import EventListener, {withOptions} from 'react-event-listener';
 
 class MyComponent extends Component {
   handleResize = () => {
     console.log('resize');
+  };
+
+  handleScroll = () => {
+    console.log('scroll');
   };
 
   handleMouseMove = () => {
@@ -38,7 +42,11 @@ class MyComponent extends Component {
   render() {
     return (
       <div>
-        <EventListener target="window" onResize={this.handleResize} />
+        <EventListener
+          target="window"
+          onResize={this.handleResize}
+          onScroll={withOptions(this.handleScroll, {passive: true, capture: false})}
+        />
         <EventListener target={document} onMouseMoveCapture={this.handleMouseMove} />
       </div>
     );

--- a/package.json
+++ b/package.json
@@ -53,5 +53,6 @@
   },
   "dependencies": {
     "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",
+    "warning": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "sinon": "^1.17.6"
   },
   "dependencies": {
-    "object-assign": "^4.1.0",
-    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0"
+    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "sinon": "^1.17.6"
   },
   "dependencies": {
+    "object-assign": "^4.1.0",
     "react-addons-shallow-compare": "^0.14.0 || ^15.0.0"
   }
 }

--- a/src/define-property.js
+++ b/src/define-property.js
@@ -1,0 +1,4 @@
+// Error avoidance of flowtype
+export default function defineProperty(o, p, attr) {
+  return Object.defineProperty(o, p, attr);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 import React, {Component, PropTypes} from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
+import warning from 'warning';
 import * as supports from './supports';
 
 type EventOptions = {
@@ -77,6 +78,9 @@ function forEachListener(
 }
 
 export function withOptions(handler: Function, options: EventOptions): {handler: Function, options: EventOptions} {
+  if (process.env.NODE_ENV !== 'production' && typeof options === 'undefined') {
+    warning(options, '[react-event-listener] Should be specified options in withOptions.');
+  }
   return {handler, options: mergeDefaultEventOptions(options)};
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@
 
 import React, {Component, PropTypes} from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
-import assign from 'object-assign';
 import * as supports from './supports';
 
 type EventOptions = {
@@ -14,6 +13,10 @@ const defaultEventOptions: EventOptions = {
   capture: false,
   passive: false,
 };
+
+function mergeDefaultEventOptions(options: Object) {
+  return Object.assign({}, defaultEventOptions, options);
+}
 
 function getEventListenerArgs(eventName: string, callback: Function, options: EventOptions): Array<any> {
   const args = [eventName, callback];
@@ -68,13 +71,13 @@ function forEachListener(
     if (isObject) {
       iteratee(eventName, prop.handler, prop.options);
     } else {
-      iteratee(eventName, prop, assign({}, defaultEventOptions, {capture}));
+      iteratee(eventName, prop, mergeDefaultEventOptions({capture}));
     }
   }
 }
 
 export function withOptions(handler: Function, options: EventOptions): {handler: Function, options: EventOptions} {
-  return {handler, options: assign({}, defaultEventOptions, options)};
+  return {handler, options: mergeDefaultEventOptions(options)};
 }
 
 export default class EventListener extends Component {

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,28 @@
 
 import React, {Component, PropTypes} from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
+import assign from 'object-assign';
 import * as supports from './supports';
 
-function on(target: Object, eventName: string, callback: Function, capture?: boolean): void {
+type EventOptions = {
+  capture: boolean;
+  passive: boolean;
+};
+
+const defaultEventOptions: EventOptions = {
+  capture: false,
+  passive: false,
+};
+
+function getEventListenerArgs(eventName: string, callback: Function, options: EventOptions): Array<any> {
+  const args = [eventName, callback];
+  args.push(supports.passiveOption ? options : options.capture);
+  return args;
+}
+
+function on(target: Object, eventName: string, callback: Function, options: EventOptions): void {
   if (supports.addEventListener) {
-    target.addEventListener(eventName, callback, capture);
+    target.addEventListener.apply(target, getEventListenerArgs(eventName, callback, options));
   } else if (supports.attachEvent) { // IE8+ Support
     target.attachEvent(`on${eventName}`, () => {
       callback.call(target);
@@ -14,9 +31,9 @@ function on(target: Object, eventName: string, callback: Function, capture?: boo
   }
 }
 
-function off(target: Object, eventName: string, callback: Function, capture?: boolean): void {
+function off(target: Object, eventName: string, callback: Function, options: EventOptions): void {
   if (supports.removeEventListener) {
-    target.removeEventListener(eventName, callback, capture);
+    target.removeEventListener.apply(target, getEventListenerArgs(eventName, callback, options));
   } else if (supports.detachEvent) { // IE8+ Support
     target.detachEvent(`on${eventName}`, callback);
   }
@@ -32,18 +49,32 @@ const state = {};
 
 function forEachListener(
   props: Props,
-  iteratee: (eventName: string, listener: Function, capture?: boolean) => any
+  iteratee: (eventName: string, listener: Function, options?: EventOptions) => any
 ): void {
   for (const name in props) {
-    if (name.substring(0, 2) === 'on' && props[name] instanceof Function) {
-      const capture = name.substr(-7).toLowerCase() === 'capture';
+    if (name.substring(0, 2) !== 'on') continue;
 
-      let eventName = name.substring(2).toLowerCase();
-      eventName = capture ? eventName.substring(0, eventName.length - 7) : eventName;
+    const prop = props[name];
+    const type = typeof prop;
+    const isObject = type === 'object';
+    const isFunction = type === 'function';
 
-      iteratee(eventName, props[name], capture);
+    if (!isObject && !isFunction) continue;
+
+    const capture = name.substr(-7).toLowerCase() === 'capture';
+    let eventName = name.substring(2).toLowerCase();
+    eventName = capture ? eventName.substring(0, eventName.length - 7) : eventName;
+
+    if (isObject) {
+      iteratee(eventName, prop.handler, prop.options);
+    } else {
+      iteratee(eventName, prop, assign({}, defaultEventOptions, {capture}));
     }
   }
+}
+
+export function withOptions(handler: Function, options: EventOptions): {handler: Function, options: EventOptions} {
+  return {handler, options: assign({}, defaultEventOptions, options)};
 }
 
 export default class EventListener extends Component {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -3,7 +3,7 @@ import React, {Component} from 'react';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import {spy} from 'sinon';
-import EventListener from './index';
+import EventListener, {withOptions} from './index';
 
 import {
   render,
@@ -191,6 +191,48 @@ describe('EventListener', () => {
           <EventListener
             target={document}
             onClickCapture={() => calls.push('outer')}
+          />
+          <button
+            ref={(c) => button = c}
+            onClick={() => calls.push('inner')}
+          />
+        </div>,
+        node
+      );
+
+      assert.strictEqual(calls.length, 0);
+      button.click();
+      assert.deepEqual(calls, [
+        'outer',
+        'inner',
+      ], 'Should be called in the right order.');
+    });
+  });
+
+  describe('when using withOptions helper', () => {
+    it('should return handler function & event options of merging default values', () => {
+      const obj = withOptions(() => 'test', {});
+      assert.strictEqual(obj.handler(), 'test');
+      assert.deepEqual(obj.options, {capture: false, passive: false});
+    });
+
+    it('should work with using withOptions helper', () => {
+      const handleClick = spy();
+
+      render(<EventListener target={document} onClick={withOptions(handleClick, {})} />, node);
+      document.body.click();
+      assert.strictEqual(handleClick.callCount, 1);
+    });
+
+    it('attaches listeners with capture (withOptions)', () => {
+      let button;
+      const calls = [];
+
+      render(
+        <div>
+          <EventListener
+            target={document}
+            onClick={withOptions(() => calls.push('outer'), {capture: true})}
           />
           <button
             ref={(c) => button = c}

--- a/src/supports.js
+++ b/src/supports.js
@@ -17,16 +17,24 @@ export const detachEvent = canUseDOM && 'detachEvent' in window;
 
 // Passive options
 // Inspired by https://github.com/Modernizr/Modernizr/blob/master/feature-detects/dom/passiveeventlisteners.js
-export const passiveOption = () => {
-  let supportsPassiveOption = false;
+export const passiveOption = (() => {
+  let cache = null;
 
-  try {
-    window.addEventListener('test', null, defineProperty({}, 'passive', {
-      get() {
-        supportsPassiveOption = true;
-      },
-    }));
-  } catch (e) {} // eslint-disable-line no-empty
+  return (() => {
+    if (cache != null) return cache;
 
-  return supportsPassiveOption;
-};
+    let supportsPassiveOption = false;
+
+    try {
+      window.addEventListener('test', null, defineProperty({}, 'passive', {
+        get() {
+          supportsPassiveOption = true;
+        },
+      }));
+    } catch (e) {} // eslint-disable-line no-empty
+
+    cache = supportsPassiveOption;
+
+    return supportsPassiveOption;
+  })();
+})();

--- a/src/supports.js
+++ b/src/supports.js
@@ -1,4 +1,5 @@
 // @flow
+import defineProperty from './define-property';
 
 // Inspired by https://github.com/facebook/fbjs/blob/master/packages/fbjs/src/core/ExecutionEnvironment.js
 export const canUseDOM = !!(
@@ -13,3 +14,19 @@ export const removeEventListener = canUseDOM && 'removeEventListener' in window;
 // IE8+ Support
 export const attachEvent = canUseDOM && 'attachEvent' in window;
 export const detachEvent = canUseDOM && 'detachEvent' in window;
+
+// Passive options
+// Inspired by https://github.com/Modernizr/Modernizr/blob/master/feature-detects/dom/passiveeventlisteners.js
+export const passiveOption = () => {
+  let supportsPassiveOption = false;
+
+  try {
+    window.addEventListener('test', null, defineProperty({}, 'passive', {
+      get() {
+        supportsPassiveOption = true;
+      },
+    }));
+  } catch (e) {} // eslint-disable-line no-empty
+
+  return supportsPassiveOption;
+};


### PR DESCRIPTION
### Description

Added support for passive options for performance improvements such as `onscroll` and `touchmove` and etc.

#### Usage

```javascript
import React, {Component} from 'react';
import EventListener, {withOptions} from 'react-event-listener';

class MyComponent extends Component {
  handleScroll = () => {
    console.log('scroll');
  };

  render() {
    return <EventListener
      target="window"
      onScroll={withOptions(this.handleScroll, {passive: true, capture: false})}
    />;
  }
}
```

### Note: 

* Added dependency of `object-assign`. (For default value merge and cross browser support)


### Related Issues

* [add / removeEventListener passive options? · Issue #11 · oliviertassinari/react-event-listener](https://github.com/oliviertassinari/react-event-listener/issues/11)

Closes #11.