### PR TITLE
Accept only single child

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,9 +89,9 @@ export function withOptions(handler: Function, options: EventOptions): {handler:
 class EventListener extends Component {
   static propTypes = {
     /**
-     * You can provide a children too.
+     * You can provide a single child too.
      */
-    children: PropTypes.node,
+    children: PropTypes.element,
     /**
      * The DOM target to listen to.
      */


### PR DESCRIPTION
Just a cosmetic update for propTypes declaration, render function always expects to render only one element, so in case I mistakenly provide more than one child it fails with error:

```
invariant.js?4599:39 Uncaught Invariant Violation: EventListener.render(): A valid ReactComponent must be returned. You may have returned undefined, an array or some other invalid object.
```