### PR TITLE
add babel-runtime in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "sinon": "^1.17.6"
   },
   "dependencies": {
+    "babel-runtime": "^6.20.0",
     "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",
     "warning": "^3.0.0"
   },


### PR DESCRIPTION
Add babel-runtime in dependencies according to https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime

This fixes the issue #21 