### PR TITLE
Making iteration over subset of props more explicit for Flow

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,12 +56,13 @@ function forEachListener(
   props: Props,
   iteratee: (eventName: string, listener: Function, options?: EventOptions) => any,
 ): void {
-  Object.keys(props).forEach((name) => {
+  const { children, target, ...eventProps } = props;
+  Object.keys(eventProps).forEach((name) => {
     if (name.substring(0, 2) !== 'on') {
       return;
     }
 
-    const prop = props[name];
+    const prop = eventProps[name];
     const type = typeof prop;
     const isObject = type === 'object';
     const isFunction = type === 'function';


### PR DESCRIPTION
This addresses #35. The problem is that currently, the code extracts an array of strings corresponding to the key names in the Props object, filters the list, which results in us knowing that target or children will not be part of the list. It then accesses the Props object with this list, however Flow cannot (in 0.42.0) follow the logic and understand that children or target could not be in the list, which causes the Flow error.

Here's a minimal example which causes the same problem
```
type Props = {
  target?: EventTarget,
  [event: string]: string
};

const a = (x: Props) => {
  Object.keys(x).forEach((name) => {
    if (name.substring(0, 2) !== 'on') {
      return;
    }
    console.log(x[name] + 'hi')
  })
}
```

By explicitly destructuring the Props, and removing the two differently typed key-value pairs, Flow understands that only strings could be left, and lets us proceed. Thus no Flow error, and tests still pass.